### PR TITLE
Add AKS to AKS volumes migration support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The CLI extension will let you:
 
 - Take a snapshot of cluster state for back/restore purposes
 - Migrate Persistent Volumes resources from ACS to AKS
+- Migrate Persistent Volumes resources from AKS to AKS
 - Move Unmanaged Data Disks from ACS to AKS 
 - Move Managed Data Disks from ACS to AKS
 - Migrate clusters between regions
@@ -54,6 +55,7 @@ Group
 
 Commands:
     copy-volumes: Copy Persistent Volumes from ACS to AKS.
+    copy-aks-volumes: Copy Persistent Volumes from AKS to AKS.
     export      : Export a Kubernetes cluster's resources to disk.
 ```
 
@@ -66,6 +68,10 @@ Commands:
 ### migrate and use your own source and target kubeconfigs
 
 `az kube copy-volumes --source-kubeconfig=~/.source --target-kubeconfig=~/.target --source-acs-name=myacs --target-aks-name=myaks`
+
+### migrate AKS cluster volumes to AKS
+
+`az kube copy-aks-volumes --source-aks-name test-kube-source --source-aks-resourcegroup test-kube-source --target-aks-name test-kube-target --target-aks-resourcegroup test-kube-target --source-kubeconfig source.config --target-kubeconfig target.config`
 
 ### Backups a cluster's state
 

--- a/azext_kube/__init__.py
+++ b/azext_kube/__init__.py
@@ -13,6 +13,7 @@ class KubeCommandsLoader(AzCommandsLoader):
     def load_command_table(self, args):
         with self.command_group('kube') as g:
             g.custom_command('copy-volumes', 'copy_volumes')
+            g.custom_command('copy-aks-volumes', 'copy_aks_volumes')
             g.custom_command('export', 'export_cluster_to_dir')
         return self.command_table
 
@@ -22,6 +23,13 @@ class KubeCommandsLoader(AzCommandsLoader):
             c.argument('target_aks_name', options_list=['--target-aks-name'])
             c.argument('acs_resource_group', options_list=['--acs-resourcegroup'])
             c.argument('aks_resource_group', options_list=['--aks-resourcegroup'])
+            c.argument('source_kubeconfig', options_list=['--source-kubeconfig'])
+            c.argument('target_kubeconfig', options_list=['--target-kubeconfig'])
+        with self.argument_context('kube copy-aks-volumes') as c:
+            c.argument('source_aks_name', options_list=['--source-aks-name'])
+            c.argument('target_aks_name', options_list=['--target-aks-name'])
+            c.argument('source_aks_resource_group', options_list=['--source-aks-resourcegroup'])
+            c.argument('target_aks_resource_group', options_list=['--target-aks-resourcegroup'])
             c.argument('source_kubeconfig', options_list=['--source-kubeconfig'])
             c.argument('target_kubeconfig', options_list=['--target-kubeconfig'])
         with self.argument_context('kube export') as c:

--- a/azext_kube/_help.py
+++ b/azext_kube/_help.py
@@ -39,6 +39,40 @@ helps['kube copy-volumes'] = """
             az kube copy-volumes --source-kubeconfig=/.myconfig --source-acs-name=acs-cluster --target-aks-name=aks-cluster
 """
 
+helps['kube copy-aks-volumes'] = """
+    type: command
+    short-summary: Copy Persistent Volumes from one AKS to another AKS.
+    long-summary: >
+        Creates Managed Disks in target AKS resource group using storage snapshots and copies PV k8s resources from one AKS cluster to another AKS cluster.
+        Supports cross-region copies.
+    parameters:
+        - name: --source-aks-name
+          type: string
+          short-summary: Name of the source AKS instance
+        - name: --target-aks-name
+          type: string
+          short-summary: Name of the target AKS instance
+        - name: --source-aks-resourcegroup
+          type: string
+          short-summary: Name of the source AKS cluster resource group
+        - name: --target-aks-resourcegroup
+          type: string
+          short-summary: Name of the target AKS cluster resource group
+        - name: --source-kubeconfig
+          type: string
+          short-summary: Path to the source cluster kubeconfig file
+        - name: --target-kubeconfig
+          type: string
+          short-summary: Path to the target cluster kubeconfig file
+    examples:
+        - name: Copy all Persistent Volumes from ACS to AKS
+          text: >
+            az kube copy-aks-volumes --source-aks-name=source-aks-cluster --target-aks-name=target-aks-cluster --source-aks-resourcegroup=rg1 --target-aks-resourcegroup=rg2
+        - name: Copy using a custom Kubeconfig file
+          text: >
+            az kube copy-aks-volumes --source-kubeconfig=/.myconfig --source-aks-name=source-aks-cluster-name --target-aks-name=target-aks-cluster-name
+"""
+
 helps['kube export'] = """
     type: command
     short-summary: Export a Kubernetes cluster's resources to disk

--- a/azext_kube/kube_operations.py
+++ b/azext_kube/kube_operations.py
@@ -47,6 +47,51 @@ def get_clusters_info(source_acs_name, acs_resourcegroup, target_aks_name, aks_r
     return info
 
 
+def get_aks_clusters_info(source_aks_name, source_aks_resourcegroup, target_aks_name, target_aks_resourcegroup):
+    
+    aks_clusters = az_cli(['aks', 'list'])
+
+#Target AKS Cluster Info
+
+    filtered_target_aks = [c for c in aks_clusters if c['resourceGroup'].lower() == target_aks_resourcegroup and c['name'] == target_aks_name]
+
+    if not filtered_target_aks:
+        raise CLIError(
+            'Target AKS Cluster with name {0} not found'.format(target_aks_name))
+
+    target_aks = filtered_target_aks[0]
+    print("Found target AKS cluster with name {0}".format(target_aks_name))
+
+    target_resource_group = target_aks['resourceGroup']
+    target_mc_resource_group = 'mc_{0}_{1}_{2}'.format(target_resource_group, target_aks['name'], target_aks['location'])
+    target_location = target_aks['location']
+
+#Source AKS Cluster Info
+    filtered_source_aks = [c for c in aks_clusters if c['resourceGroup'].lower() == source_aks_resourcegroup and c['name'] == source_aks_name]
+
+    if not filtered_source_aks:
+        raise CLIError(
+            'Source AKS Cluster with name {0} not found'.format(source_aks_name))
+
+    source_aks = filtered_source_aks[0]
+    print("Found source AKS cluster with name {0}".format(source_aks_name))
+
+    source_resource_group = source_aks['resourceGroup']
+    source_mc_resource_group = 'mc_{0}_{1}_{2}'.format(source_resource_group, source_aks['name'], source_aks['location'])
+    source_location = source_aks['location']
+
+
+
+    ClusterInfo = namedtuple('ClusterInfo', 'source_aks_resource_group source_aks_mc_resource_group target_aks_resource_group target_aks_mc_resource_group source_cluster_name target_cluster_name source_aks_location target_aks_location')
+
+    info = ClusterInfo(source_aks_resource_group=source_resource_group, source_aks_mc_resource_group=source_mc_resource_group, source_cluster_name=source_aks_name,
+                       target_aks_mc_resource_group=target_mc_resource_group, target_aks_resource_group=target_resource_group,
+                       target_cluster_name=target_aks_name, source_aks_location=source_location, target_aks_location=target_location)
+
+    return info
+
+
+
 def get_kubeconfig(cli_service, name, resource_group):
     output_path = os.path.join(os.getcwd(), str(uuid.uuid4()))
 
@@ -107,6 +152,56 @@ def copy_volumes(source_acs_name, target_aks_name, acs_resourcegroup, aks_resour
 
     if not target_kubeconfig:
         target_kubeconfig = get_kubeconfig('aks', clusters_info.aks_name, clusters_info.aks_resource_group)
+        remove_target_config = True
+
+    # this is a shady business right here.
+    for pv in source_pvs:
+        pv_copy_result = kubewrapper.create_pv_from_current_pv(target_kubeconfig, pv)
+
+        if pv_copy_result:
+            print("Persistent Volume migration successful")
+        else:
+            print("Failed migrating Persistent Volumes")
+
+    if remove_source_config:
+        os.remove(source_kubeconfig)
+    
+    if remove_target_config:
+        os.remove(target_kubeconfig)
+        
+    print("All done")
+
+
+def copy_aks_volumes(source_aks_name, target_aks_name, source_aks_resourcegroup, target_aks_resourcegroup, source_kubeconfig=None, target_kubeconfig=None):
+    clusters_info = get_aks_clusters_info(source_aks_name, source_aks_resourcegroup,  target_aks_name, target_aks_resourcegroup)
+
+    remove_source_config = False
+    remove_target_config = False
+
+    if not source_kubeconfig:
+        source_kubeconfig = get_kubeconfig('aks', clusters_info.source_aks_name, clusters_info.source_aks_resource_group)
+        remove_source_config = True
+
+    source_pvs = get_pvs_from_source(source_kubeconfig)
+
+    print("Starting migration of {0} Persistent Volumes from AKS cluster {1} in {2} to AKS cluster {3} in {4}".format(len(source_pvs), clusters_info.source_cluster_name,
+        clusters_info.source_aks_location, clusters_info.target_cluster_name, clusters_info.target_aks_location))
+
+    for pv in source_pvs:
+        if pv.spec.azure_disk.kind.lower() == 'managed':
+            disk_name = pv.spec.azure_disk.disk_name
+            disk = storage.copy_disk_to_disk(clusters_info.source_aks_mc_resource_group, disk_name ,clusters_info.target_aks_mc_resource_group)
+            pv.target_disk_name = disk['name']
+            pv.target_disk_uri = disk['id']
+        else:
+            disk_uri = pv.spec.azure_disk.disk_uri
+            disk = storage.copy_vhd_to_disk(disk_uri, clusters_info.aks_mc_resource_group)
+            pv.target_disk_uri = disk['creationData']['sourceUri']
+    print("Disks migration successful")
+    print("Starting Persistent Volume creation on target cluster")
+
+    if not target_kubeconfig:
+        target_kubeconfig = get_kubeconfig('aks', clusters_info.target_aks_name, clusters_info.target_aks_resource_group)
         remove_target_config = True
 
     # this is a shady business right here.


### PR DESCRIPTION
Add new command line `copy-aks-volumes` with options:
`--source-aks-name`
`--source-aks-resourcegroup` 
`--target-aks-name`
`--target-aks-resourcegroup`
`--source-kubeconfig`
`--target-kubeconfig`
This command will copy all volumes from one aks cluster to another with the same logic as the original ACS to AKS migration implementation (snapshot, create volume from snapshot, delete snapshot, create pv from volume)

Please merge
G.